### PR TITLE
Check that MS connection is persitent

### DIFF
--- a/selvansgeo.py
+++ b/selvansgeo.py
@@ -284,6 +284,11 @@ class SelvansGeo():
 
         # store the current role
         self.currentRole = roleSelected
+        
+        # check that MS Connection is still valid. It seems that the credential manager
+        # somehow resets the connections when reconnecting to PG.
+        if self.qtmsdb.isValid() is False:
+            self.qtmsdb, isMSOpened = self.msdb.createQtMSDB()
 
     # Desactivate all UI except connection part
     def switchUiMode(self, mode):


### PR DESCRIPTION
This is not the best way to deal with this problem.

Ideally, the connections should be established when the Selvans button is clicked, not when Selvans is loaded in QGIS... But resolving that implies a plugin refactoring...